### PR TITLE
Cut off aurora background higher on page

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
   .wrap{
     display:grid;gap:16px;padding:16px;max-width:1400px;margin:0 auto;height:calc(100vh - 64px);
     grid-template-columns:1fr;transition:grid-template-columns .35s ease;overflow:hidden;
-    background:linear-gradient(to bottom, transparent 0%, transparent 20%, var(--bg) 40%, var(--bg) 100%);
+    background:linear-gradient(to bottom, transparent 0%, transparent 10%, var(--bg) 25%, var(--bg) 100%);
     position:relative;z-index:1;
   }
   /* default order: left, main, right */


### PR DESCRIPTION
- Reduce transparent area to 0-10% (was 0-20%)
- Solid black starts at 25% (was 40%)
- Ensures no aurora visible at bottom of results page