### PR TITLE
Cut off aurora background higher on page

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 
   /* Aurora */
   .aurora-bg{ pointer-events:none; filter:saturate(1.12) contrast(1.06); }
-  .aurora-bg.fullscreen{ position:fixed; inset:0; z-index:0; }
+  .aurora-bg.fullscreen{ position:fixed; top:0; left:0; right:0; bottom:50%; z-index:0; }
   .aurora-bg.css-fallback{
     background:
       radial-gradient(120% 80% at 12% 4%,  #29ff7a20, transparent 60%),


### PR DESCRIPTION
- Change aurora fullscreen from inset:0 to bottom:50%
- Aurora now only renders in top half of viewport
- Prevents aurora from showing at bottom of results page